### PR TITLE
Fix typos across docs

### DIFF
--- a/docs/research/eyetracking/index.md
+++ b/docs/research/eyetracking/index.md
@@ -4,6 +4,6 @@ For setting up the long-range eye-tracking system in the fMRI room (MR8), please
 
 If you want more information on the stand-alone eye-tracking system to run behavioural experiments, please consult [this](PLACEHOLDER) page instead.
 
-**TODO**: here we can should the info from [this page](https://matthiasnau.com/eye_tracking.html) (we received permission from the creator). Some of the points (e.g., 1,2,6,10) are **particularly** relevant for our setup. The issues we encounter are usually related to noisy images from the camera and low/badly distributed IR illumination.
+**TODO**: here we should add the info from [this page](https://matthiasnau.com/eye_tracking.html) (we received permission from the creator). Some of the points (e.g., 1,2,6,10) are **particularly** relevant for our setup. The issues we encounter are usually related to noisy images from the camera and low/badly distributed IR illumination.
 
-**NOTE**: I am not sure whether we need this eye-tracking section. We could perhaps just keep the ET info within the relevant sections (fmri, behaviour)? Unless there is more general info that does not fit in those sections, e.g. lin to scripts, resources, manuals, overall workflow to collect, process and analyze data (which I would assume is roughly the same between fmri and behaviour).
+**NOTE**: I am not sure whether we need this eye-tracking section. We could perhaps just keep the ET info within the relevant sections (fmri, behaviour)? Unless there is more general info that does not fit in those sections, e.g. links to scripts, resources, manuals, overall workflow to collect, process and analyze data (which I would assume is roughly the same between fmri and behaviour).

--- a/docs/research/fmri/analysis/fmri-setup-env.md
+++ b/docs/research/fmri/analysis/fmri-setup-env.md
@@ -275,7 +275,7 @@ We use Conda to manage our Python environment.
     ```
 
 !!! warning
-    It's **crucial** to create a new conda environment for each new project you start. Installing new packages into the base conda environment it's a very bad practice that will eventually lead to a bloated, brittle environent with broken packages and compatibility issues. Uninstalling or re-installing Python on some machine can be a very painful (sometimes impossible) process!
+    It's **crucial** to create a new conda environment for each new project you start. Installing new packages into the base conda environment is a very bad practice that will eventually lead to a bloated, brittle environment with broken packages and compatibility issues. Uninstalling or re-installing Python on some machines can be a very painful (sometimes impossible) process!
 
 #### Setting up Spyder IDE
 

--- a/docs/research/fmri/fmri-hpc.md
+++ b/docs/research/fmri/fmri-hpc.md
@@ -421,7 +421,7 @@ Make sure to check **both files**, as the error could appear in either.
 
 ### 9.3 Verifying Successful Runs
 
-If the job completed successfully, it`s time to check the output files.
+If the job completed successfully, it's time to check the output files.
 
 In our SLURM script, the `--output` directory is bound to:
 

--- a/docs/research/fmri/fmri-procedure.md
+++ b/docs/research/fmri/fmri-procedure.md
@@ -175,7 +175,7 @@ The stimulus computer's desktop is located in the **control room**. It is the se
     - **Screen Width**: 28.35 visual degrees
 
 **TODO:** MATLAB and PTB have been updated to newer version!
-**TODO:** the strcture of these sections is a bit confusing. We list the instruments in the section above, then we explain what to do at the scanner room, then we go back to describing instruments.. perhaps we should streamline this? or probably just make two different pages, one for instrument, one for general step-by-step procedure, and one for frequent errors and solutions/workarounds?
+**TODO:** the structure of these sections is a bit confusing. We list the instruments in the section above, then we explain what to do at the scanner room, then we go back to describing instruments.. perhaps we should streamline this? Or probably just make two different pages, one for instruments, one for a general step-by-step procedure, and one for frequent errors and solutions/workarounds?
 ---
 
 ### Trigger Boxes
@@ -983,4 +983,4 @@ In case of an emergency involving the MRI system or facility:
 
 ---
 
-**TODO**: add additional info on DICOM (no enhanced, missing values, etc.). see also [this](https://github.com/rordenlab/dcm2niix/tree/3e02980597669ed8a9db073e824b4f74cccb597a/Philips) where Chris Rorden explains some practical issues with Phillips DICOMS, particularly the section on missing info (which we should probably link somewhere), and [this thread](https://www.nitrc.org/forum/forum.php?thread_id=15186&forum_id=4703), which explains issues with the enhanced DICOMs.
+**TODO**: add additional info on DICOM (no enhanced, missing values, etc.). See also [this](https://github.com/rordenlab/dcm2niix/tree/3e02980597669ed8a9db073e824b4f74cccb597a/Philips) where Chris Rorden explains some practical issues with Philips DICOMs, particularly the section on missing info (which we should probably link somewhere), and [this thread](https://www.nitrc.org/forum/forum.php?thread_id=15186&forum_id=4703), which explains issues with the enhanced DICOMs.


### PR DESCRIPTION
## Summary
- fix wording in FMRI procedure overview
- correct DICOM note spelling
- improve environment setup warning
- update eye-tracking notes
- correct punctuation in HPC guide

## Testing
- `mkdocs build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455c0ee1e883248d56f64767f63ce6