### PR TITLE
add link to on-site mouse tracker

### DIFF
--- a/docs/research/behaviour/bh-tasks.md
+++ b/docs/research/behaviour/bh-tasks.md
@@ -27,11 +27,11 @@ Templates are organized into two sections:
 
     ---
 
-    A structured template for designing an in-person mouse tracker experiment.
+    An example of on-site mouse tracker coded with Psychopy.
 
     See [PLACEHOLDER](#)
 
-    [:octicons-arrow-right-24: PLACEHOLDER](#)
+    [:octicons-arrow-right-24: PLACEHOLDER](https://github.com/TimManiquet/live-motor-task/tree/main)
 
 </div>
 


### PR DESCRIPTION
added link to tim's github of live mouse tracker, a demo that includes a psychopy script with mouse tracking