### PR TITLE
docs: add cross-references between wiki sections

### DIFF
--- a/docs/get-started/student-starter-pack.md
+++ b/docs/get-started/student-starter-pack.md
@@ -24,6 +24,9 @@ Developing strong coding skills is crucial for success in our lab. Here are some
 
 8. If you're going to use MatLab, you can check this [live script tutorial](https://github.com/VisCog/MatlabForTheBehavioralSciences/tree/main) to learn the fundamentals.
 
+!!! tip "Hoplab coding practices"
+    After completing these tutorials, check out the lab's [Coding practices](../research/coding/index.md) guide for our specific conventions on project organization, environments, and version control.
+
 ## Miscellaneous
 
 <div class="grid cards" markdown>

--- a/docs/research/behaviour/bh-tasks.md
+++ b/docs/research/behaviour/bh-tasks.md
@@ -59,6 +59,9 @@ Templates are organized into two sections:
 
 </div>
 
+!!! tip "Setting up your experiment"
+    For instructions on deploying these tasks online or running them on-site, see [Experimental setup](experimental-setup/index.md).
+
 <!--
 __TODO__: Add inverse MDS info Emily
 -->

--- a/docs/research/behaviour/index.md
+++ b/docs/research/behaviour/index.md
@@ -42,6 +42,9 @@ We hope this section helps you conduct your behavioural research with ease and p
 
 </div>
 
+!!! tip "Data Management"
+    Follow the lab's [Research Data Management guidelines](../rdm/index.md) for storing and organizing your behavioural data.
+
 <!--
 __TODO__: [Klara] Add info on how/where to rent lab coats (mandatory when testing in the hospital)
 __TODO__: [Klara]: Add info on shredding paper with sensitive information

--- a/docs/research/eeg/eeg-acquisition.md
+++ b/docs/research/eeg/eeg-acquisition.md
@@ -175,3 +175,6 @@ Hooray, you are now ready to start acquiring EEG data! To do so, follow these st
 3. Use a plastic toothpick to remove the gel from all the gaps in the head cap.
 4. If necessary, fill the tub with clean lukewarm water and add a bit of the 70% alcohol solution to it. Soak the electrodes, the head cap and the syringes in it for a few seconds to disinfect them, and then rinse everything again with lukewarm water.
 5. Let the caps and syringes dry flat on the round table (do not hang the caps to dry). Put the electrode sets back on the rack (make sure they are stable and don't fall on the floor).
+
+!!! info "Data storage"
+    After transferring your data, make sure to follow the lab's [Research Data Management guidelines](../rdm/current.md) for organizing and backing up your dataset.

--- a/docs/research/ethics/MEC.md
+++ b/docs/research/ethics/MEC.md
@@ -1,5 +1,8 @@
 # Filing your study with the Ethical Committee UZ/KU Leuven
 
+!!! info "Which approval do you need?"
+    This page covers the **EC onderzoek (Medical Ethics Committee)** pathway, required for fMRI studies, patient studies, UZ Leuven studies, and TMS/tDCS research. For behavioral studies not involving medical procedures, see [SMEC](SMEC.md) instead. Check the [ethics overview](index.md) for a decision tree.
+
 ## Step 1: Register your study at the UZ Leuven Clinical Trial Center (CTC)
 
 1. **Fill in [this online form](https://www.uzleuven.be/en/register-a-study)** in order to register your study in the UZ/KU Leuven central clinical research database.

--- a/docs/research/ethics/SMEC.md
+++ b/docs/research/ethics/SMEC.md
@@ -1,5 +1,8 @@
 # Filing your study with the Social and Societal Ethics Committee
 
+!!! info "Which approval do you need?"
+    This page covers the **SMEC** pathway for behavioral research not involving medical procedures. For fMRI studies, patient studies, or TMS/tDCS research, see [EC onderzoek](MEC.md) instead. Check the [ethics overview](index.md) for a decision tree.
+
 SMEC evaluates research on human subjects that is not related to health science practices or includes medical or pharmacological procedures.
 
 As of February 2020, the SMEC performs an **integrated ethics and privacy (GDPR) check** on all new applications through the [**PRET platform**](https://www.kuleuven.be/pret) (external applicants can download the application form [here](https://research.kuleuven.be/en/integrity-ethics/ethics/committees/smec/documenten-1/application-form)).

--- a/docs/research/fmri/analysis/fmri-bids-conversion.md
+++ b/docs/research/fmri/analysis/fmri-bids-conversion.md
@@ -429,4 +429,7 @@ By following these detailed steps, you'll ensure your data is properly organized
 
 ---
 
+!!! info "Next steps: Data storage"
+    Once your data is in BIDS format, make sure to follow the lab's [data management guidelines](../../rdm/current.md) for storing and backing up your dataset. See the [ManGO guide](../../rdm/mango_active.md) for uploading your data to the lab's active research data storage.
+
 Now that you have your data in BIDS format, we can proceed to data pre-processing and quality assessment. See the next guide for instructions. [--> Pre-processing and QA](fmri-prepocessing-qa.md)

--- a/docs/research/fmri/analysis/fmri-setup-env.md
+++ b/docs/research/fmri/analysis/fmri-setup-env.md
@@ -9,6 +9,9 @@ Welcome to the fMRI analysis environment setup guide. This walkthrough will help
     - **CPU:** Multi-core processor (4+ cores)
     - **GPU:** NVIDIA GPU with CUDA support (optional, but beneficial)
 
+!!! tip "General coding setup"
+    For general guidance on setting up Python/Conda environments, Git, and IDE configuration, see [Coding practices](../../coding/index.md).
+
 ## Folder Structure
 
 Our lab uses a specific folder structure for fMRI projects. Here's an overview:

--- a/docs/research/fmri/fmri-hpc.md
+++ b/docs/research/fmri/fmri-hpc.md
@@ -25,6 +25,9 @@ This guide describes how to connect to the KU Leuven/VSC HPC cluster, manage you
 VSC offers a [full documentation](https://docs.vscentrum.be/) of all the services, but in case of question of problems, you
 may contact the [local support team at KU Leuven](https://docs.vscentrum.be/contact_vsc.html).
 
+!!! tip "General coding setup"
+    For general guidance on setting up Python/Conda environments and Git, see [Coding practices](../coding/index.md).
+
 ## 1. Prerequisites
 
 1. You have a valid VSC account (e.g., `vsc12345`). Request one [here](https://vlaams-supercomputing-centrum-vscdocumentation.readthedocs-hosted.com/en/latest/index.html).

--- a/docs/research/fmri/fmri-procedure.md
+++ b/docs/research/fmri/fmri-procedure.md
@@ -82,6 +82,9 @@ Before going to the hospital, ensure that you have the following forms ready:
 
 ## Participant Arrival and Registration
 
+!!! tip "Recruitment and compensation"
+    For details on recruiting participants and compensation rates, see the [participant recruitment and reimbursement guide](../behaviour/bh-participants.md).
+
 ### Participant Registration
 
 Upon arriving at the hospital, participants must register at the **main entrance**. The registration procedure varies depending on whether they hold a Belgian ID:

--- a/docs/research/fmri/index.md
+++ b/docs/research/fmri/index.md
@@ -38,6 +38,9 @@ Welcome to the landing page for all things related to functional MRI (fMRI) in o
 
 </div>
 
+!!! tip "Data Management"
+    Make sure to follow the lab's [Research Data Management guidelines](../rdm/index.md) throughout your project. See the [temporary RDM guidelines](../rdm/current.md) for current recommended practices on data storage and organization.
+
 ## Quick Links to Resources
 
 Here are some helpful links to external resources for fMRI data analysis, tools, and tutorials:


### PR DESCRIPTION
## Summary
Add missing cross-links to improve navigation and discoverability:
- Link RDM guidelines from fMRI, EEG, and behaviour section landing pages
- Add "Next steps: Data storage" box at end of BIDS conversion page
- Add mutual "Which approval do you need?" admonitions between MEC and SMEC ethics pages
- Link coding practices from fMRI environment setup and HPC pages
- Add participant recruitment cross-reference in fMRI procedure page
- Connect task scripts page → experimental setup
- Link student starter pack → coding practices

All cross-links use MkDocs Material admonitions (`!!! tip`, `!!! info`) for visual consistency.

## Test plan
- [ ] Verify all admonition boxes render correctly (tip/info styling)
- [ ] Click each internal link to confirm it resolves to the correct page
- [ ] Check that no duplicate links were introduced (pages that already linked to the target)